### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # ExcelReport
 This reporting engine is built on NPOI.
 
-#About
+# About
 In fact, now say that ExcelReport is the report engine is still too early, but the assembly since I determined to continue, this is the original intention!
 <br/><br/>
 <B>So now, what ExcelReport can do for you?</B><br/>
 If you have the demand, export data to Excel, ExcelReport may be a good choice.
 
-#Detailed introduction
+# Detailed introduction
 <a>http://www.cnblogs.com/hanzhaoxin/tag/ExcelReport/</a>
 
-#ExcelReport on SNS
+# ExcelReport on SNS
 QQ Group:116476496
 <a target="_blank" href="http://shang.qq.com/wpa/qunwpa?idkey=6c043f8cf9bc6d0b8f817c640b0343788c3c5665d61e94cce8a0d39c2b319dc6"><img border="0" src="http://pub.idqqimg.com/wpa/images/group.png" alt="ExcelReport交流群" title="ExcelReport交流群"></a>
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
